### PR TITLE
chore: Tweak benchmarking through Cargo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,10 +26,12 @@ jobs:
       run: cargo fmt -- --check
 
     - name: Build
-      run: cargo build --verbose
+      run: cargo build
 
     - name: Run tests
-      run: cargo test --verbose
+      run: cargo test
 
+    # Run benchmarks as tests because we're not interested in analyzing
+    # performance in the CI build, we just want to make sure they work.
     - name: Run benchmarks
-      run: cargo bench
+      run: cargo test --benches

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,14 @@ version = "0.1.0"
 authors = ["Chathan Driehuys <chathan@driehuys.com>"]
 edition = "2018"
 
+[lib]
+bench = false
+
+[[bin]]
+name = "raytracer"
+path = "src/main.rs"
+bench = false
+
 [[bench]]
 name = "sphere"
 harness = false


### PR DESCRIPTION
Tweak our benchmarking setup to allow for easier usage through Cargo.
Disabling the default benchmarking harness allows us to use Criterion's
CLI flags directly without the default harness attempting to parse them.

We also don't need to run the benchmarks in analysis mode during our CI
build. The CI environment has wildly different performance from build to
build, so we only want to make sure the benchmark runs.

See: https://bheisler.github.io/criterion.rs/book/faq.html#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options
