### PR TITLE
Clean up Clippy warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     - uses: Swatinem/rust-cache@v2
 
     - name: Lint
-      run: cargo clippy
+      run: cargo clippy -- -D warnings
 
     - name: Format
       run: cargo fmt -- --check

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -177,7 +177,7 @@ impl Camera {
         let origin = &transform * Tuple::new_point(0, 0, 0);
         let direction = (pixel - origin).normalized();
 
-        return Ray::new(origin, direction);
+        Ray::new(origin, direction)
     }
 
     /// Render a world using the camera.

--- a/src/intersections.rs
+++ b/src/intersections.rs
@@ -124,7 +124,7 @@ impl<'a> IntersectionInfo<'a> {
     }
 
     pub fn object(&self) -> &'a dyn Shape {
-        &*self.object
+        self.object
     }
 
     pub fn point(&self) -> Tuple {
@@ -215,6 +215,11 @@ impl<'a> Intersections<'a> {
     /// This is always the intersection with the lowest non-negative `t` value.
     pub fn hit(&self) -> Option<&Intersection> {
         self.intersections.iter().find(|i| i.t >= 0.0)
+    }
+
+    /// Returns `true` if the intersection collection is empty.
+    pub fn is_empty(&self) -> bool {
+        self.intersections.is_empty()
     }
 
     /// Find the number of elements in the intersection collection.

--- a/src/linear/matrices.rs
+++ b/src/linear/matrices.rs
@@ -45,6 +45,7 @@ impl Matrix {
     ///     7.0, 8.0, 9.0,
     /// );
     /// ```
+    #[allow(clippy::too_many_arguments)]
     pub fn square_3(
         v1: f64,
         v2: f64,
@@ -76,6 +77,7 @@ impl Matrix {
     ///     5.0, 4.0, 3.0, 2.0,
     /// );
     /// ```
+    #[allow(clippy::too_many_arguments)]
     pub fn square_4(
         v1: f64,
         v2: f64,

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,7 @@ fn main() {
 
     let floor = {
         let mut floor = Plane::default();
-        floor.set_material(floor_material.clone());
+        floor.set_material(floor_material);
 
         floor
     };
@@ -61,8 +61,10 @@ fn main() {
         left
     };
 
-    let mut world = World::default();
-    world.objects = vec![&floor, &middle, &left, &right];
+    let world = World {
+        objects: vec![&floor, &middle, &left, &right],
+        ..Default::default()
+    };
 
     let camera = Camera::new(1000, 500, FRAC_PI_3).with_transform(view_transform(
         &Tuple::new_point(0.0, 1.5, -5.0),

--- a/src/objects/plane.rs
+++ b/src/objects/plane.rs
@@ -54,7 +54,11 @@ mod test {
 
         let intersections = p.intersect_local(&r);
 
-        assert_eq!(intersections.len(), 0);
+        assert!(
+            intersections.is_empty(),
+            "Found unexpected intersections: {:?}",
+            intersections
+        );
     }
 
     #[test]
@@ -64,7 +68,11 @@ mod test {
 
         let intersections = p.intersect_local(&r);
 
-        assert_eq!(intersections.len(), 0);
+        assert!(
+            intersections.is_empty(),
+            "Found unexpected intersections: {:?}",
+            intersections
+        );
     }
 
     #[test]

--- a/src/objects/shape.rs
+++ b/src/objects/shape.rs
@@ -84,7 +84,7 @@ pub trait Shape: std::fmt::Debug {
     fn intersect(&self, ray: &Ray) -> Intersections {
         let local_ray = ray.transformed(&self.transform().inverted());
 
-        self.intersect_local(&&local_ray)
+        self.intersect_local(&local_ray)
     }
 
     /// Find the normal vector at a point on the object's surface.
@@ -102,7 +102,7 @@ pub trait Shape: std::fmt::Debug {
         let inverted_transform = self.transform().inverted();
 
         let local_point = &inverted_transform * *point;
-        let local_normal = self.normal_at_local(&&local_point);
+        let local_normal = self.normal_at_local(&local_point);
         let world_normal = &inverted_transform.transposed() * local_normal;
 
         // Since the proper calculations involve taking the submatrix containing

--- a/src/objects/sphere.rs
+++ b/src/objects/sphere.rs
@@ -82,7 +82,11 @@ mod test {
 
         let intersections = sphere.intersect_local(&ray);
 
-        assert_eq!(intersections.len(), 0);
+        assert!(
+            intersections.is_empty(),
+            "Found unexpected intersections: {:?}",
+            intersections
+        );
     }
 
     #[test]


### PR DESCRIPTION
Clean up Clippy warnings and ensure that the CI build fails if new warnings are introduced.

Closes #2
