### PR TITLE
fix: Broken rendering after parallelization

### DIFF
--- a/src/camera.rs
+++ b/src/camera.rs
@@ -205,12 +205,12 @@ impl Camera {
     /// let _image = camera.render(&world);
     /// ```
     pub fn render(&self, world: &World) -> Canvas {
-        let pixels = (0..self.vsize)
+        let pixels = (0..self.hsize)
             .into_par_iter()
-            .map(|y| {
-                (0..self.hsize)
+            .map(|x| {
+                (0..self.vsize)
                     .into_par_iter()
-                    .map(move |x| {
+                    .map(move |y| {
                         let ray = self.ray_for_pixel(x, y);
                         world.color_at(&ray)
                     })

--- a/src/canvas/mod.rs
+++ b/src/canvas/mod.rs
@@ -44,8 +44,8 @@ impl Canvas {
     }
 
     pub fn from_pixels(pixels: Vec<Vec<Color>>) -> Self {
-        let height = pixels.len();
-        let width = pixels.get(0).map(Vec::len).unwrap_or(0);
+        let width = pixels.len();
+        let height = pixels.get(0).map(Vec::len).unwrap_or(0);
 
         Self {
             width,


### PR DESCRIPTION
Rendering of non-square images was broken by the parallelization of
rendering due to mixing up the structure of the canvas pixels. This
wasn't caught by our render tests because they use square images.
